### PR TITLE
Changes due to Hardhat version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ To build the smart contract we would be using [Hardhat](https://hardhat.org/). H
   npx hardhat
   ```
 
-  - Select `Create a basic sample project`
+  - Select `Create a JavaScript project`
   - Press enter for the already specified `Hardhat Project root`
   - Press enter for the question on if you want to add a `.gitignore`
-  - Press enter for `Do you want to install this sample project's dependencies with npm (@nomiclabs/hardhat-waffle ethereum-waffle chai @nomiclabs/hardhat-ethers ethers)?`
+  - Press enter for `Do you want to install this sample project's dependencies with npm (@nomiclabs/hardhat-toolbox)?`
 
 Now you have a hardhat project ready to go!
 
@@ -72,10 +72,10 @@ contract Greeter {
 
 ```
 
-- This contract declares a string - `greeting`. There are also two methods and a constructor. The constructor initiates the greeting variable with the provided string value. 
+- This contract declares a string - `greeting`. There are also two methods and a constructor. The constructor initiates the greeting variable with the provided string value.
 - The `greet` method returns the greeting string. Since this is a `view` function, it costs no gas, and requires no signing to execute.
 - The `setGreeting` method sets the greeting string with a provided user value. Since this updates the smart contract state, it costs gas, and requires signing.
-**One interesting thing to note about the `setGreeting` method is that it uses the Hardhat's console.log contract, so we can actually debug and see to what values was `greeting` changed to!**
+  **One interesting thing to note about the `setGreeting` method is that it uses the Hardhat's console.log contract, so we can actually debug and see to what values was `greeting` changed to!**
 
 <Quiz questionId="d7a6c9a2-2aca-47de-b5a9-805aafd04831" />
 
@@ -93,7 +93,7 @@ This command starts a local blockchain node for you. You should be able to see s
 
 ![](https://i.imgur.com/NkwsCXn.png)
 
-Now, you can continue by deploying the contract to the local blockchain using Hardhat, by running `npx hardhat run scripts/sample-script.js`. 
+Now, you can continue by deploying the contract to the local blockchain using Hardhat, by running `npx hardhat run scripts/sample-script.js`.
 
 Alternatively, you can also use something like Remix and have it deploy contracts to your local blockchain. The second method will also involve setting up Metamask to work with your local blockchain, and will give you an idea of how to locally test your React/Next.js apps using contracts running on the local blockchain as well, so let's do that.
 
@@ -162,8 +162,7 @@ This is the same code, we explained above
   ![](https://i.imgur.com/bhAwIRf.png)
 
 - Now to deploy, go to deployment tab and in your environment select `Injected Web3`, make sure that the account connected is the one that you imported above and the network is `Localhost 8545` on your MetaMask
-- 
-  ![](https://i.imgur.com/zgGKlQm.png)
+- ![](https://i.imgur.com/zgGKlQm.png)
   ![](https://i.imgur.com/qrJTtLi.png)
 
 - Set a greeting and click on deploy
@@ -176,7 +175,7 @@ This is the same code, we explained above
 
 - Check your terminal which was running your hardhat node, it should have the console.log
 
-    ![local-node-console-](https://user-images.githubusercontent.com/56781761/156940719-d41dbe65-9dde-40b5-83c4-6641c0fa9737.png)
+  ![local-node-console-](https://user-images.githubusercontent.com/56781761/156940719-d41dbe65-9dde-40b5-83c4-6641c0fa9737.png)
 
 <Quiz questionId="662f7e38-0490-4417-8ce0-0689fa7e3bb6" />
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To build the smart contract we would be using [Hardhat](https://hardhat.org/). H
 - To setup a Hardhat project, Open up a terminal and execute these commands
 
   ```bash
+  mkdir Local-Blockchain-Testing
+  cd Local-Blockchain-Testing
   npm init --yes
   npm install --save-dev hardhat
   ```
@@ -32,19 +34,19 @@ To build the smart contract we would be using [Hardhat](https://hardhat.org/). H
   - Select `Create a JavaScript project`
   - Press enter for the already specified `Hardhat Project root`
   - Press enter for the question on if you want to add a `.gitignore`
-  - Press enter for `Do you want to install this sample project's dependencies with npm (@nomiclabs/hardhat-toolbox)?`
+  - Press enter for `Do you want to install this sample project's dependencies with npm (@nomicfoundation/hardhat-toolbox)?`
 
 Now you have a hardhat project ready to go!
 
 If you are not on mac, please do this extra step and install these libraries as well :)
 
 ```bash
-npm install --save-dev @nomiclabs/hardhat-waffle ethereum-waffle chai @nomiclabs/hardhat-ethers ethers
+npm install --save-dev @nomicfoundation/hardhat-toolbox
 ```
 
 and press `enter` for all the questions.
 
-The basic hardhat project also comes with a sample smart contract. We'll be using this smart contract in our example. You should see this contract in `contracts\Greeter.sol`. It should look something like this:
+In the contracts folder, create a new solidity file called Greeter.sol. Now we would write some code in the file.
 
 ```Solidity
 //SPDX-License-Identifier: Unlicense
@@ -93,7 +95,36 @@ This command starts a local blockchain node for you. You should be able to see s
 
 ![](https://i.imgur.com/NkwsCXn.png)
 
-Now, you can continue by deploying the contract to the local blockchain using Hardhat, by running `npx hardhat run scripts/sample-script.js`.
+Now, you can continue by deploying the contract to the local blockchain using Hardhat. To do so, update the code inside `scripts/deploy.js` with the code below.
+
+```js
+// We require the Hardhat Runtime Environment explicitly here. This is optional
+// but useful for running the script in a standalone fashion through `node <script>`.
+//
+// You can also run a script with `npx hardhat run <script>`. If you do that, Hardhat
+// will compile your contracts, add the Hardhat Runtime Environment's members to the
+// global scope, and execute the script.
+const hre = require("hardhat");
+
+async function main() {
+  // We get the contract to deploy
+  const Greeter = await hre.ethers.getContractFactory("Greeter");
+  const greeter = await Greeter.deploy("Hello, Hardhat!");
+
+  await greeter.deployed();
+
+  console.log("Greeter deployed to:", greeter.address);
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+```
+
+Deploy to local blockchain by running `npx hardhat run scripts/deploy.js`.
 
 Alternatively, you can also use something like Remix and have it deploy contracts to your local blockchain. The second method will also involve setting up Metamask to work with your local blockchain, and will give you an idea of how to locally test your React/Next.js apps using contracts running on the local blockchain as well, so let's do that.
 


### PR DESCRIPTION
Hardhat recently published its new upgrade, so the instructions won't work properly.

I have kept the old `Greeter.sol` contract, as using any other contract would require replacing with new screenshots.